### PR TITLE
feat: add changable functions of nested key or dot notation dict in util

### DIFF
--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -22,5 +22,3 @@ uvicorn
 fastapi
 python-consul
 dnspython
-dotty-dict
-deepmerge

--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -22,3 +22,5 @@ uvicorn
 fastapi
 python-consul
 dnspython
+dotty-dict
+deepmerge

--- a/src/spaceone/core/utils.py
+++ b/src/spaceone/core/utils.py
@@ -13,8 +13,6 @@ from dateutil.parser import isoparse
 from typing import Tuple
 from pathlib import Path
 from typing import Union
-import dotty_dict
-import mergedeep
 
 YAML_LOADER = yaml.Loader
 YAML_LOADER.add_implicit_resolver(
@@ -455,15 +453,6 @@ def dict_to_hash(dict_value: dict) -> str:
     encoded = json.dumps(dict_value, sort_keys=True).encode()
     dhash.update(encoded)
     return dhash.hexdigest()
-
-
-def change_dict_with_nested_key(dict_value: dict) -> dict:
-    gen_dict = {}
-    for key, value in dict_value.items():
-        dot = dotty_dict.dotty()
-        dot[key] = value
-        mergedeep.merge(gen_dict, dot.to_dict())
-    return gen_dict
 
 
 def change_dict_with_dot_notation(dict_value: dict, key='', dots=None) -> dict:


### PR DESCRIPTION
* Changed the dot argument to an immutable value in the change_dict_with_dot_notation function to solve the problem that the value was passed when the scope changed. ( dots = None )
* A function test was performed with the data below.
```python
# Test samples
    dot_notation_sample = {
        "a.b.c": "d",
        "q.w.e.r": "t",
        "a.b.b": "a",
        "q.q.e.r": "t",
        "b.c": "g"
    }

    dot_notation_sample2 = {
        "a.b.c": "d",
        "a.w.e.r": "t",
        "b.b.b": "a",
        "b.q.e.r": "t",
        "b.c": "g"
    }

    nested_dict_sample = {
        'a': {'b': {'c': 'd', 'b': 'a'}},
        'q': {'w': {'e': {'r': 't'}}, 'q': {'e': {'r': 't'}}},
        'b': {'c': 'g'}
    }

    nested_dict_sample2 = {
        'a': {'g': {'k': 'l'}},
        'q': {'n': {'k': {'u': 'y'}}}
    }


# results
  {'a': {'b': {'c': 'd', 'b': 'a'}}, 'q': {'w': {'e': {'r': 't'}}, 'q': {'e': {'r': 't'}}}, 'b': {'c': 'g'}}
  {'a': {'b': {'c': 'd'}, 'w': {'e': {'r': 't'}}}, 'b': {'b': {'b': 'a'}, 'q': {'e': {'r': 't'}}, 'c': 'g'}}
  
  {'a.b.c': 'd', 'a.b.b': 'a', 'q.w.e.r': 't', 'q.q.e.r': 't', 'b.c': 'g'}
  {'a.g.k': 'l', 'q.n.k.u': 'y'}
```