### PR TITLE
feat add sub command for checking global configuration

### DIFF
--- a/src/spaceone/core/command.py
+++ b/src/spaceone/core/command.py
@@ -30,7 +30,7 @@ def create_project(project_name=None, directory=None):
               help='Port of gRPC server', show_default=True)
 @click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
-@click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
+@click.option('-m', '--module-path', type=click.Path(exists=True), multiple=True, help='Module path')
 def grpc(package, port=None, config_file=None, module_path=None):
     """Run a gRPC server"""
     _set_server_config(package, module_path, port, config_file=config_file)
@@ -45,7 +45,7 @@ def grpc(package, port=None, config_file=None, module_path=None):
               help='Port of REST server', show_default=True)
 @click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
-@click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
+@click.option('-m', '--module-path', type=click.Path(exists=True), multiple=True, help='Module path')
 def rest(package, host=None, port=None, config_file=None, module_path=None):
     """Run a FastAPI REST server"""
     _set_server_config(package, module_path, port, config_file=config_file)
@@ -56,7 +56,7 @@ def rest(package, host=None, port=None, config_file=None, module_path=None):
 @click.argument('package')
 @click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='config file path')
-@click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
+@click.option('-m', '--module-path', type=click.Path(exists=True), multiple=True, help='Module path')
 def scheduler(package, config_file=None, module_path=None):
     """Run a scheduler server"""
     _set_server_config(package, module_path, config_file=config_file)
@@ -67,7 +67,7 @@ def scheduler(package, config_file=None, module_path=None):
 @click.argument('package')
 @click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
-@click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
+@click.option('-m', '--module-path', type=click.Path(exists=True), multiple=True, help='Module path')
 @click.option('-o', '--output', default='yaml', help='Output format',
               type=click.Choice(['json', 'yaml']), show_default=True)
 def show_config(package, config_file=None, module_path=None, output=None):

--- a/src/spaceone/core/command.py
+++ b/src/spaceone/core/command.py
@@ -28,12 +28,12 @@ def create_project(project_name=None, directory=None):
 @click.argument('package')
 @click.option('-p', '--port', type=int, default=lambda: os.environ.get('SPACEONE_PORT', 50051),
               help='Port of gRPC server', show_default=True)
-@click.option('-c', '--config', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
+@click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
 @click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
-def grpc(package, port=None, config=None, module_path=None):
+def grpc(package, port=None, config_file=None, module_path=None):
     """Run a gRPC server"""
-    _set_server_config(package, module_path, port, config_file=config)
+    _set_server_config(package, module_path, port, config_file=config_file)
     pygrpc.serve()
 
 
@@ -43,41 +43,41 @@ def grpc(package, port=None, config=None, module_path=None):
               help='Host of REST server', show_default=True)
 @click.option('-p', '--port', type=int, default=lambda: os.environ.get('SPACEONE_PORT', 8000),
               help='Port of REST server', show_default=True)
-@click.option('-c', '--config', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
+@click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
 @click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
-def rest(package, host=None, port=None, config=None, module_path=None):
+def rest(package, host=None, port=None, config_file=None, module_path=None):
     """Run a FastAPI REST server"""
-    _set_server_config(package, module_path, port, config_file=config)
+    _set_server_config(package, module_path, port, config_file=config_file)
     fastapi.serve()
 
 
 @cli.command()
 @click.argument('package')
-@click.option('-c', '--config', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
+@click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='config file path')
 @click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
-def scheduler(package, config=None, module_path=None):
+def scheduler(package, config_file=None, module_path=None):
     """Run a scheduler server"""
-    _set_server_config(package, module_path, config_file=config)
+    _set_server_config(package, module_path, config_file=config_file)
     scheduler_v1.serve()
 
 
 @cli.command()
 @click.argument('package')
-@click.option('-c', '--config', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
+@click.option('-c', '--config-file', type=click.Path(exists=True), default=lambda: os.environ.get('SPACEONE_CONFIG_FILE'),
               help='Config file path')
 @click.option('-m', '--module_path', type=click.Path(exists=True), multiple=True, help='Module path')
 @click.option('-o', '--output', default='yaml', help='Output format',
               type=click.Choice(['json', 'yaml']), show_default=True)
-def show_config(package, config=None, module_path=None, output=None):
+def show_config(package, config_file=None, module_path=None, output=None):
     """Show global configurations"""
-    _set_server_config(package, module_path, config_file=config)
+    _set_server_config(package, module_path, config_file=config_file)
     _print_config(output)
 
 
 @cli.command()
-@click.option('-c', '--config', type=str, help='Config file path')
+@click.option('-c', '--config-file', type=str, help='Config file path')
 @click.option('-d', '--dir', type=str, help="Directory containing test files",
               default=lambda: os.environ.get('SPACEONE_WORKING_DIR', os.getcwd()))
 @click.option('-f', '--failfast', help="Fast failure flag", is_flag=True)
@@ -86,11 +86,11 @@ def show_config(package, config=None, module_path=None, output=None):
                                                    "ex) -p domain.domain.name=new_name -p options.update_mode=false",
               multiple=True)
 @click.option('-v', '--verbose', count=True, help='Verbosity level', default=1)
-def test(config=None, dir=None, failfast=False, scenario: str = None, parameters: List[str] = None, verbose=1):
+def test(config_file=None, dir=None, failfast=False, scenario: str = None, parameters: List[str] = None, verbose=1):
     """Unit tests for source code"""
     # set config
     if config:
-        os.environ['TEST_CONFIG'] = config
+        os.environ['TEST_CONFIG'] = config_file
 
     if scenario:
         os.environ['TEST_SCENARIO'] = scenario

--- a/src/spaceone/core/config/__init__.py
+++ b/src/spaceone/core/config/__init__.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import sys
 import consul
 
 from spaceone.core import utils
@@ -16,9 +15,6 @@ def init_conf(package, **kwargs):
 
     _GLOBAL['PACKAGE'] = package
     _GLOBAL['SERVICE'] = package.rsplit('.', 1)[-1:][0]
-
-    if 'server_type' in kwargs:
-        _GLOBAL['SERVER_TYPE'] = kwargs['server_type']
 
     if 'host' in kwargs:
         _GLOBAL['HOST'] = kwargs['HOST']

--- a/src/spaceone/core/config/default_conf.py
+++ b/src/spaceone/core/config/default_conf.py
@@ -9,7 +9,6 @@ PACKAGE = None
 SERVICE = None
 
 # Server Configuration
-SERVER_TYPE = None
 PORT = 50051
 HOST = '127.0.0.1'
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- add `show-config` command for checking global configuration
```
spaceone show-config --help
Usage: command.py show-config [OPTIONS] PACKAGE

  Show global configurations

Options:
  -c, --config-file PATH         Config file path
  -m, --module-path PATH    Module path
  -o, --output [json|yaml]  Output format  [default: yaml]
  --help                    Show this message and exit.
```