### PR TITLE
Delete self.resource of _resource in transaction decorator

### DIFF
--- a/src/spaceone/core/service/service.py
+++ b/src/spaceone/core/service/service.py
@@ -54,7 +54,7 @@ def transaction(func=None, verb=None, append_meta=None):
     def wrapper(func):
         @functools.wraps(func)
         def wrapped_func(self, params):
-            _resource = self._metadata.get('resource') or self.resource or self.__class__.__name__
+            _resource = self._metadata.get('resource') or self.__class__.__name__
             _verb = verb or func.__name__
             with _TRACER.start_as_current_span(f'{_resource}.{_verb}',
                                                context=_get_span_context(self._metadata)) as span:


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
* delete self.resource of _resource in transaction decorator because of console-api-v2' proxy service error