### PR TITLE
Resolve DeprecationWarning issue

### DIFF
--- a/src/spaceone/core/command.py
+++ b/src/spaceone/core/command.py
@@ -5,7 +5,6 @@ import unittest
 from typing import List
 
 import click
-import pkg_resources
 
 from spaceone.core import config, pygrpc, fastapi, utils, model
 from spaceone.core import plugin as plugin_srv
@@ -213,8 +212,7 @@ def _set_python_path(package: str, source_root: str = None, module_path: List[st
                 sys.path.insert(0, path)
 
     if '.' in package:
-        pkg_resources.declare_namespace(package)
-
+        __path__ = __import__('pkgutil').extend_path(__path__, package)
     try:
         __import__(package)
     except Exception:


### PR DESCRIPTION
If you are using python 3.8+, remove `pkg_resources`

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Since our microservices are using Python 3.8+, no need for `pkg_resources` anymore.

### Known issue
If you use Python 3.8+, `pkg_reousrces` will be deprecated, so I changed minor code for future development.