### PR TITLE
Add injected_params for service account agent mode

### DIFF
--- a/src/spaceone/core/error.py
+++ b/src/spaceone/core/error.py
@@ -291,3 +291,9 @@ class ERROR_MESSAGE_FORMAT(ERROR_UNKNOWN):
 
 class ERROR_CACHE_KEY_FORMAT(ERROR_UNKNOWN):
     _message = "Cache key format is invalid. (key = {key})"
+
+
+class ERROR_SERVICE_ACCOUNT_CANNOT_BE_DELETED_WITH_EXISTING_APP(ERROR_INVALID_ARGUMENT):
+    _status_code = "INVALID_OPERATION"
+    _message = """Service Account cannot be deleted as long as an associated App exists. 
+    Please delete the App before deleting the Service Account. (error_class = {error_class}, key = {key})"""

--- a/src/spaceone/core/handler/authentication_handler.py
+++ b/src/spaceone/core/handler/authentication_handler.py
@@ -111,6 +111,8 @@ class SpaceONEAuthenticationHandler(BaseAuthenticationHandler):
                 'iat': 'int',   # issued at
                 'jti': 'str',   # jwt id (token_key | client_id), Optional
                 'permissions': 'list',  # permissions, Optional
+                'projects': 'list',     # project_ids, if workspace member, Optional
+                'injected_params': 'dict',  # injected parameters, override parameters, Optional
                 'ver': 'str',   # jwt version
         """
 
@@ -122,6 +124,7 @@ class SpaceONEAuthenticationHandler(BaseAuthenticationHandler):
         workspace_id = token_info.get("wid")
         permissions = token_info.get("permissions")
         projects = token_info.get("projects")
+        injected_params = token_info.get("injected_params")
 
         self.transaction.set_meta("authorization.token_type", token_type)
         self.transaction.set_meta("authorization.role_type", role_type)
@@ -131,6 +134,7 @@ class SpaceONEAuthenticationHandler(BaseAuthenticationHandler):
         self.transaction.set_meta("authorization.workspace_id", workspace_id)
         self.transaction.set_meta("authorization.permissions", permissions)
         self.transaction.set_meta("authorization.projects", projects)
+        self.transaction.set_meta("authorization.injected_params", injected_params)
 
         if owner_type == "USER":
             self.transaction.set_meta("authorization.user_id", audience)

--- a/src/spaceone/core/handler/mutation_handler.py
+++ b/src/spaceone/core/handler/mutation_handler.py
@@ -12,6 +12,7 @@ class SpaceONEMutationHandler(BaseMutationHandler):
         user_projects: list = self.transaction.get_meta("authorization.projects")
         user_id: str = self.transaction.get_meta("authorization.user_id")
         set_user_id: str = self.transaction.get_meta("authorization.set_user_id")
+        injected_params: dict = self.transaction.get_meta("authorization.injected_params")
 
         if user_role_type == "SYSTEM_TOKEN":
             if domain_id:
@@ -34,5 +35,8 @@ class SpaceONEMutationHandler(BaseMutationHandler):
 
         if set_user_id:
             params["user_id"] = user_id
+
+        if injected_params:
+            params.update(injected_params)
 
         return params


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
In Service Account Agent mode, `injected_params`, in other words, `service_account_id`, are added to apps created by the Service Account. To handle this in the handler, code has been added.