### PR TITLE
Update Dockerfile to use Python 3.10 and improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
-ENV PYTHONUNBUFFERED 1
-ENV SRC_DIR /tmp/src
-ENV EXTENSION_DIR /opt/spaceone
-ENV PYTHONPATH "${PYTHONPATH}:/opt"
+ARG PACKAGE_VERSION
+
+ENV PYTHONUNBUFFERED=1
+ENV SRC_DIR=/tmp/src
+ENV EXTENSION_DIR=/opt/spaceone
+ENV PYTHONPATH="${PYTHONPATH}:/opt"
 
 RUN apt-get update \
   && apt-get install -y wget build-essential
@@ -12,3 +14,7 @@ COPY pkg/pip_requirements.txt pip_requirements.txt
 COPY templates/opt/cloudforet ${EXTENSION_DIR}
 
 RUN pip install -r pip_requirements.txt
+
+COPY ./src ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN pip install --no-cache-dir .

--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -32,4 +32,3 @@ opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-instrumentation-logging
 opentelemetry-exporter-prometheus
-spaceone-core


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- upgraded python version `3.8` -> `3.10` 
- when create core image, replaced PyPI-based spaceone-core install with local source installation using setup.py, with version injection via PACKAGE_VERSION

### Known issue
- We’ll need to upgrade to python`3.11` soon.
