### PR TITLE
Add thread-safe handler initialization using double-checked locking

### DIFF
--- a/src/spaceone/core/handler/__init__.py
+++ b/src/spaceone/core/handler/__init__.py
@@ -26,7 +26,7 @@ _HANDLER_INFO = {
     "mutation": [],
     "event": [],
 }
-_HANDLER_THREAD_LOCK = threading.Lock()
+_HANDLER_INIT_LOCK = threading.Lock()
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ def get_event_handlers() -> List[BaseEventHandler]:
 
 def _check_init_state() -> None:
     if not _HANDLER_INFO["init"]:
-        with _HANDLER_THREAD_LOCK:
+        with _HANDLER_INIT_LOCK:
             if not _HANDLER_INFO["init"]:
                 _init_handlers()
                 _HANDLER_INFO["init"] = True

--- a/src/spaceone/core/handler/__init__.py
+++ b/src/spaceone/core/handler/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+import threading
 from typing import List
 from spaceone.core.base import CoreObject
 from spaceone.core import config
@@ -25,6 +26,7 @@ _HANDLER_INFO = {
     "mutation": [],
     "event": [],
 }
+_HANDLER_THREAD_LOCK = threading.Lock()
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,5 +147,7 @@ def get_event_handlers() -> List[BaseEventHandler]:
 
 def _check_init_state() -> None:
     if not _HANDLER_INFO["init"]:
-        _init_handlers()
-        _HANDLER_INFO["init"] = True
+        with _HANDLER_THREAD_LOCK:
+            if not _HANDLER_INFO["init"]:
+                _init_handlers()
+                _HANDLER_INFO["init"] = True


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Add thread-safe handler initialization using double-checked locking
### Known issue
When the server starts and both the first and second requests arrive simultaneously, the handler was being initialized twice.

To resolve this, a thread lock was introduced. Only the first and second requests are affected by the lock, and since subsequent requests bypass the initialization logic, there appears to be no performance issue.