### PR TITLE
chore(tracing): set span kind for client and server

### DIFF
--- a/src/spaceone/core/connector/space_connector.py
+++ b/src/spaceone/core/connector/space_connector.py
@@ -3,6 +3,8 @@ import logging
 from typing import Any, List, Tuple
 from google.protobuf.json_format import MessageToDict
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
 
 from spaceone.core.connector import BaseConnector
 from spaceone.core import pygrpc
@@ -13,7 +15,7 @@ from spaceone.core.error import *
 __all__ = ["SpaceConnector"]
 
 _LOGGER = logging.getLogger(__name__)
-
+_TRACER = trace.get_tracer(__name__)
 
 class SpaceConnector(BaseConnector):
     name = "SpaceConnector"
@@ -46,7 +48,8 @@ class SpaceConnector(BaseConnector):
         return self._client
 
     def dispatch(self, method: str, params: dict = None, **kwargs) -> Any:
-        return self._call_api(method, params, **kwargs)
+        with _TRACER.start_as_current_span(method, kind=SpanKind.CLIENT):
+            return self._call_api(method, params, **kwargs)
 
     def _call_api(
         self,

--- a/src/spaceone/core/service/__init__.py
+++ b/src/spaceone/core/service/__init__.py
@@ -6,7 +6,7 @@ import time
 from typing import Generator, Union, Literal, Any
 
 from opentelemetry import trace
-from opentelemetry.trace import format_trace_id
+from opentelemetry.trace import format_trace_id, SpanKind
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from spaceone.core.base import CoreObject
@@ -129,7 +129,9 @@ def transaction(
             _traceparent = self.metadata.get("traceparent")
 
             with _TRACER.start_as_current_span(
-                f"{self.resource}.{_verb}", context=_get_span_context(_traceparent)
+                f"{self.resource}.{_verb}", 
+                context=_get_span_context(_traceparent),
+                kind=SpanKind.SERVER
             ) as span:
                 self.current_span_context = span.get_span_context()
                 trace_id = format_trace_id(self.current_span_context.trace_id)


### PR DESCRIPTION
## 제목

`chore(tracing): 클라이언트와 서버에 span kind 설정`

---

### Category

* [ ] 신규 기능 (New feature)
* [ ] 버그 수정 (Bug fix)
* [ ] 개선 (Improvement)
* [ ] 리팩터 (Refactor)
* [x] 기타 (etc)

---

### Description

* `SpaceConnector.dispatch`: **CLIENT** span 으로 래핑 (외부 요청 표현)
* `transaction` 데코레이터: **SERVER** span 설정 (내부 요청 표현)

해당 변경으로 트레이스의 정확성과 관찰성을 개선합니다.

---

### Known issue

* 현재 span kind 는 `SpaceConnector(client)`와 `transaction(server)` 데코레이터에만 적용되었기 때문에, 이 구조를 따르지 않는 트레이스의 경우 추적이 어려울 수 있습니다.
* console-api-v2 등을 통해서 호출되지 않고 내부적으로 호출되는 호출 사항에 대한 trace 는 명확히 trace 하기 어려울 수 있습니다. 
